### PR TITLE
feat(game): Implement pause and resume functionality in GameScreen

### DIFF
--- a/src/engine/Core.java
+++ b/src/engine/Core.java
@@ -119,8 +119,11 @@ public final class Core {
 								bonusLife, width, height, FPS);
 
 						LOGGER.info("Starting " + WIDTH + "x" + HEIGHT + " game screen at " + FPS + " fps.");
-						frame.setScreen(currentScreen);
+						returnCode = frame.setScreen(currentScreen);
 						LOGGER.info("Closing game screen.");
+						if(returnCode == 1) {
+							break;
+						}
 
 						gameState = ((GameScreen) currentScreen).getGameState();
 
@@ -130,6 +133,9 @@ public final class Core {
 
 					} while (gameState.teamAlive() && gameState.getLevel() <= NUM_LEVELS);
 
+					if (returnCode== 1) {
+						break;
+					}
 					LOGGER.info("Starting " + WIDTH + "x" + HEIGHT + " score screen at " + FPS + " fps, with a score of "
 							+ gameState.getScore() + ", "
 							+ gameState.getLivesRemaining() + " lives remaining, "

--- a/src/engine/Core.java
+++ b/src/engine/Core.java
@@ -108,8 +108,11 @@ public final class Core {
 								bonusLife, width, height, FPS, achievementManager);
 
 						LOGGER.info("Starting " + WIDTH + "x" + HEIGHT + " game screen at " + FPS + " fps.");
-						frame.setScreen(currentScreen);
+						returnCode = frame.setScreen(currentScreen);
 						LOGGER.info("Closing game screen.");
+						if(returnCode == 1) {
+							break;
+						}
 
 						gameState = ((GameScreen) currentScreen).getGameState();
 
@@ -119,6 +122,9 @@ public final class Core {
 
 					} while (gameState.teamAlive() && gameState.getLevel() <= gameSettings.size());
 
+					if (returnCode== 1) {
+						break;
+					}
 					LOGGER.info("Starting " + WIDTH + "x" + HEIGHT + " score screen at " + FPS + " fps, with a score of "
 							+ gameState.getScore() + ", "
 							+ gameState.getLivesRemaining() + " lives remaining, "

--- a/src/engine/DrawManager.java
+++ b/src/engine/DrawManager.java
@@ -607,7 +607,7 @@ public final class DrawManager {
 		backBufferGraphics.setColor(Color.WHITE);
 		drawCenteredBigString(screen, pauseString, screen.getHeight()/2);
 
-		String returnMenu = "PRESS ENTER TO RETURN TO TITLE";
+		String returnMenu = "PRESS BACKSPACE TO RETURN TO TITLE";
 		backBufferGraphics.setFont(fontRegular);
 		backBufferGraphics.setColor(Color.WHITE);
 		drawCenteredRegularString(screen, returnMenu, screen.getHeight()-50);

--- a/src/engine/DrawManager.java
+++ b/src/engine/DrawManager.java
@@ -570,7 +570,6 @@ public final class DrawManager {
                             * 14);
         }
     }
-
     /**
      * Draws basic content of game over screen.
      *
@@ -581,10 +580,10 @@ public final class DrawManager {
      * @param isNewRecord
      *                     If the score is a new high score.
      */
-    public void drawGameOver(final Screen screen, final boolean acceptsInput,
-                             final boolean isNewRecord) {
-        String gameOverString = "Game Over";
-        String continueOrExitString = "Press Space to play again, Escape to exit";
+	public void drawGameOver(final Screen screen, final boolean acceptsInput,
+			final boolean isNewRecord) {
+		String gameOverString = "Game Over";
+		String continueOrExitString = "Press Space to play again, Escape to exit";
 
         int height = isNewRecord ? 4 : 2;
 
@@ -599,7 +598,20 @@ public final class DrawManager {
         drawCenteredRegularString(screen, continueOrExitString,
                 screen.getHeight() / 2 + fontRegularMetrics.getHeight() * 10);
     }
+	public void drawPauseOverlay(final Screen screen){
+		backBufferGraphics.setColor(new Color(0,0,0,200));
+		backBufferGraphics.fillRect(0, 0, screen.getWidth(), screen.getHeight());
 
+		String pauseString = "PAUSED";
+		backBufferGraphics.setFont(fontBig);
+		backBufferGraphics.setColor(Color.WHITE);
+		drawCenteredBigString(screen, pauseString, screen.getHeight()/2);
+
+		String returnMenu = "PRESS F1 TO RETURN TO TITLE";
+		backBufferGraphics.setFont(fontRegular);
+		backBufferGraphics.setColor(Color.WHITE);
+		drawCenteredRegularString(screen, returnMenu, screen.getHeight()-50);
+	}//ADD This Screen
     /**
      * Draws high score screen title and instructions.
      *

--- a/src/engine/DrawManager.java
+++ b/src/engine/DrawManager.java
@@ -498,7 +498,7 @@ public final class DrawManager {
 		backBufferGraphics.setColor(Color.WHITE);
 		drawCenteredBigString(screen, pauseString, screen.getHeight()/2);
 
-		String returnMenu = "PRESS F1 TO RETURN TO TITLE";
+		String returnMenu = "PRESS ENTER TO RETURN TO TITLE";
 		backBufferGraphics.setFont(fontRegular);
 		backBufferGraphics.setColor(Color.WHITE);
 		drawCenteredRegularString(screen, returnMenu, screen.getHeight()-50);

--- a/src/engine/DrawManager.java
+++ b/src/engine/DrawManager.java
@@ -607,7 +607,7 @@ public final class DrawManager {
 		backBufferGraphics.setColor(Color.WHITE);
 		drawCenteredBigString(screen, pauseString, screen.getHeight()/2);
 
-		String returnMenu = "PRESS F1 TO RETURN TO TITLE";
+		String returnMenu = "PRESS ENTER TO RETURN TO TITLE";
 		backBufferGraphics.setFont(fontRegular);
 		backBufferGraphics.setColor(Color.WHITE);
 		drawCenteredRegularString(screen, returnMenu, screen.getHeight()-50);

--- a/src/engine/DrawManager.java
+++ b/src/engine/DrawManager.java
@@ -489,6 +489,25 @@ public final class DrawManager {
 	 * @param isNewRecord
 	 *                     If the score is a new high score.
 	 */
+	public void drawPauseOverlay(final Screen screen){
+		backBufferGraphics.setColor(new Color(0,0,0,200));
+		backBufferGraphics.fillRect(0, 0, screen.getWidth(), screen.getHeight());
+
+		String pauseString = "PAUSED";
+		backBufferGraphics.setFont(fontBig);
+		backBufferGraphics.setColor(Color.WHITE);
+		drawCenteredBigString(screen, pauseString, screen.getHeight()/2);
+
+		String returnMenu = "PRESS F1 TO RETURN TO TITLE";
+		backBufferGraphics.setFont(fontRegular);
+		backBufferGraphics.setColor(Color.WHITE);
+		drawCenteredRegularString(screen, returnMenu, screen.getHeight()-50);
+	}//ADD This Screen
+	/**
+	 * Draws a pause screen overlay.
+	 *
+	 * @param screen Screen to draw on.
+	 */
 	public void drawGameOver(final Screen screen, final boolean acceptsInput,
 			final boolean isNewRecord) {
 		String gameOverString = "Game Over";

--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -9,6 +9,7 @@ import engine.Cooldown;
 import engine.Core;
 import engine.GameSettings;
 import engine.GameState;
+import engine.AchievementManager;
 import entity.Bullet;
 import entity.BulletPool;
 import entity.EnemyShip;

--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -141,7 +141,7 @@ public class GameScreen extends Screen {
 			this.isPaused = !this.isPaused;
 			this.pauseCooldown.reset();
 		}
-		if (this.isPaused && inputManager.isKeyDown(KeyEvent.VK_F1) && this.returnMenuCooldown.checkFinished()) {
+		if (this.isPaused && inputManager.isKeyDown(KeyEvent.VK_ENTER ) && this.returnMenuCooldown.checkFinished()) {
 			returnCode = 1;
 			this.isRunning = false;
 		}

--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -204,7 +204,7 @@ public class GameScreen extends Screen {
 			this.isPaused = !this.isPaused;
 			this.pauseCooldown.reset();
 		}
-		if (this.isPaused && inputManager.isKeyDown(KeyEvent.VK_F1) && this.returnMenuCooldown.checkFinished()) {
+		if (this.isPaused && inputManager.isKeyDown(KeyEvent.VK_ENTER ) && this.returnMenuCooldown.checkFinished()) {
 			returnCode = 1;
 			this.isRunning = false;
 		}

--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -275,6 +275,8 @@ public class GameScreen extends Screen {
 
 			manageCollisions();
 			cleanBullets();
+			manageItemPickups();
+			cleanItems();
 
 		// End condition: formation cleared or TEAM lives exhausted.
 		if ((this.enemyShipFormation.isEmpty() || !state.teamAlive()) && !this.levelFinished) {

--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -191,7 +191,7 @@ public class GameScreen extends Screen {
 			this.isPaused = !this.isPaused;
 			this.pauseCooldown.reset();
 		}
-		if (this.isPaused && inputManager.isKeyDown(KeyEvent.VK_ENTER ) && this.returnMenuCooldown.checkFinished()) {
+		if (this.isPaused && inputManager.isKeyDown(KeyEvent.VK_BACK_SPACE) && this.returnMenuCooldown.checkFinished()) {
 			returnCode = 1;
 			this.isRunning = false;
 		}


### PR DESCRIPTION
This PR implements the core logic for pausing and resuming the game within the GameScreen, and allows the player to return to the title menu from the pause state.

 GameScreen.java
Lines 61-63 : Add new fields isPaused, pauseCooldown, and returnMenuCooldown to manage the pause state and related inputs.

Lines 164~166 : Initialize the new pause-related fields in the initialize() method.

Lines 190~ 193: In the update() method, add logic to toggle the isPaused state when the ESC key is pressed.

Lines 194~197: In the update() method, add logic to set returnCode = 1 and exit the screen when Backspace is pressed during a pause.

Line 180 : Wrap the main game logic block (player input, entity updates, collision checks, etc.) in an if (!isPaused) condition to halt game time when paused.

Lines 357~359: In the draw() method, add a call to drawPauseOverlay() when the game is paused to render the pause UI.

This PR depends on the drawPauseOverlay() method being present in DrawManager.java and the main game loop in Core.java correctly handling the returnCode.

 DrawManager.java
Lines 601~614 : drawPauseOverlay()

Adds the new method drawPauseOverlay(Screen screen).

It first draws a semi-transparent black rectangle that darkens the entire game screen.

It then renders a large, white "PAUSED" text in the center of the screen using the big font.

Finally, it displays an instruction text, "PRESS BACKSPACE TO RETURN TO TITLE", at the bottom of the screen using the regular font.
 Core.java
 