### PR TITLE
feat(ui): add High Scores button to TitleScreen and back navigation

### DIFF
--- a/src/engine/Core.java
+++ b/src/engine/Core.java
@@ -204,6 +204,15 @@ public final class Core {
                     returnCode = 2; // Start game.
                     break;
 
+                case 8:
+                    // High scores.
+                    currentScreen = new HighScoreScreen(width, height, FPS);
+                    LOGGER.info("Starting " + WIDTH + "x" + HEIGHT
+                            + " high score screen at " + FPS + " fps.");
+                    returnCode = frame.setScreen(currentScreen);
+                    LOGGER.info("Closing high score screen.");
+                    break;
+
                 default:
                     break;
             }

--- a/src/engine/DrawManager.java
+++ b/src/engine/DrawManager.java
@@ -412,13 +412,14 @@ public final class DrawManager {
 	 *               Option selected.
 	 */
 	public void drawMenu(final Screen screen, final int option, final Integer hoverOption, final int selectedIndex) {
-        String[] items = {"Play", "Achievements", "Settings", "Exit"};
+        String[] items = {"Play", "Achievements", "High scores","Settings", "Exit"};
 
-        int baseY = screen.getHeight() / 3 * 2; // same option choice, different formatting
+        int baseY = screen.getHeight() / 3 * 2 - 20; // Adjust spacing due to high society button addition
+        int spacing = (int) (fontRegularMetrics.getHeight() * 1.5);
         for (int i = 0; i < items.length; i++) {
             boolean highlight = (hoverOption != null) ? (i == hoverOption) : (i == selectedIndex);
             backBufferGraphics.setColor(highlight ? Color.GREEN : Color.WHITE);
-            drawCenteredRegularString(screen, items[i], (int) (baseY + fontRegularMetrics.getHeight() * 1.5 * i));
+            drawCenteredRegularString(screen, items[i], baseY + spacing * i);
         }
 
         /** String playString = "1-Player Mode";
@@ -610,6 +611,9 @@ public final class DrawManager {
         backBufferGraphics.setColor(Color.GREEN);
         backBufferGraphics.drawString("1-PLAYER MODE", midX / 2 - fontBigMetrics.stringWidth("1-PLAYER MODE") / 2 + 40, startY);
         backBufferGraphics.drawString("2-PLAYER MODE", midX + midX / 2 - fontBigMetrics.stringWidth("2-PLAYER MODE") / 2 + 40, startY);
+
+        // draw back button at top-left
+        drawBackButton(screen, false);
     }
 
     /**
@@ -668,29 +672,6 @@ public final class DrawManager {
         backBufferGraphics.setColor(Color.GRAY);
         drawCenteredRegularString(screen, instructionsString, screen.getHeight() / 6);
     }
-
-	public void drawVolumeBar(final Screen screen, final int volumlevel){
-		int bar_startWidth = screen.getWidth() / 2;
-		int bar_endWidth = screen.getWidth()-40;
-		int barHeight = screen.getHeight()*3/10;
-
-		String volumelabel = "Volume";
-		backBufferGraphics.setFont(fontRegular);
-		backBufferGraphics.setColor(Color.WHITE);
-		backBufferGraphics.drawLine(bar_startWidth, barHeight, bar_endWidth, barHeight);
-
-		backBufferGraphics.setColor(Color.WHITE);
-		backBufferGraphics.drawString(volumelabel, bar_startWidth-80, barHeight+7);
-
-		int indicatorX = bar_startWidth + (int)((bar_endWidth-bar_startWidth)*(volumlevel/100.0));
-		int indicatorY = barHeight+7;
-		backBufferGraphics.fillRect(indicatorX, indicatorY-13, 14, 14);
-		backBufferGraphics.setColor(Color.WHITE);
-		String volumeText = Integer.toString(volumlevel);
-		backBufferGraphics.drawString(volumeText, bar_endWidth+10, indicatorY);
-
-	}
-
 
     public void drawKeysettings(final Screen screen, int playerNum, int selectedSection, int selectedKeyIndex, boolean[] keySelected,int[] currentKeys) {
         int panelWidth = 220;
@@ -858,13 +839,14 @@ public final class DrawManager {
             fontRegularMetrics = backBufferGraphics.getFontMetrics(fontRegular);
         }
 
-        final String[] buttons = {"Play", "Achievement", "Settings", "Exit"};
+        final String[] buttons = {"Play", "Achievement", "High scores", "Settings", "Exit"};
 
-        int baseY = screen.getHeight() / 3 * 2;
+        int baseY = screen.getHeight() / 3 * 2 - 20;
+        int spacing = (int) (fontRegularMetrics.getHeight() * 1.5);
         Rectangle[] boxes= new Rectangle[buttons.length];
 
         for (int i = 0; i < buttons.length; i++) {
-            int baseline = (int) (baseY + fontRegularMetrics.getHeight() * 1.5 * i);
+            int baseline = baseY + spacing * i;
             boxes[i] = centeredStringBounds(screen, buttons[i], baseline);
         }
 

--- a/src/engine/DrawManager.java
+++ b/src/engine/DrawManager.java
@@ -596,7 +596,7 @@ public final class DrawManager {
      */
     public void drawHighScoreMenu(final Screen screen) {
         String highScoreString = "High Scores";
-        String instructionsString = "Press Space to return";
+        String instructionsString = "Press ESC to return";
 
         int midX = screen.getWidth() / 2;
         int startY = screen.getHeight() / 3;
@@ -650,7 +650,7 @@ public final class DrawManager {
 	// Made it to check if the Achievement button works temporarily.
 	public void drawAchievementMenu(final Screen screen) {
 		String AchievementsString = "Achievements";
-		String instructionsString = "Press Space to return";
+		String instructionsString = "Press ESC to return";
 		backBufferGraphics.setColor(Color.GREEN);
 		drawCenteredBigString(screen, AchievementsString, screen.getHeight() / 8);
 

--- a/src/screen/AchievementScreen.java
+++ b/src/screen/AchievementScreen.java
@@ -1,5 +1,7 @@
 package screen;
 
+import java.awt.event.KeyEvent;
+
 public class AchievementScreen extends Screen {
     public AchievementScreen(final int width, final int height, final int fps) {
         super(width, height, fps);
@@ -17,7 +19,7 @@ public class AchievementScreen extends Screen {
         super.update();
         draw();
 
-        if (inputManager.isKeyDown(java.awt.event.KeyEvent.VK_SPACE) && this.inputDelay.checkFinished()) {
+        if (inputManager.isKeyDown(KeyEvent.VK_ESCAPE) && this.inputDelay.checkFinished()) {
             this.returnCode = 1;
             this.isRunning = false;
         }

--- a/src/screen/HighScoreScreen.java
+++ b/src/screen/HighScoreScreen.java
@@ -63,6 +63,18 @@ public class HighScoreScreen extends Screen {
         if (inputManager.isKeyDown(KeyEvent.VK_SPACE)
                 && this.inputDelay.checkFinished())
             this.isRunning = false;
+
+        // back button click event
+        if (inputManager.isMouseClicked()) {
+            int mx = inputManager.getMouseX();
+            int my = inputManager.getMouseY();
+            java.awt.Rectangle backBox = drawManager.getBackButtonHitbox(this);
+
+            if (backBox.contains(mx, my)) {
+                this.returnCode = 1;
+                this.isRunning = false;
+            }
+        }
     }
     private List<Score> getPlayerScores(String mode) {
         return mode.equals("1P") ? highScores1P : highScores2P;
@@ -76,6 +88,15 @@ public class HighScoreScreen extends Screen {
         drawManager.drawHighScoreMenu(this);
         drawManager.drawHighScores(this, getPlayerScores("1P"), "1P"); // Left column
         drawManager.drawHighScores(this, getPlayerScores("2P"), "2P"); // Right column
+
+        // hover highlight
+        int mx = inputManager.getMouseX();
+        int my = inputManager.getMouseY();
+        java.awt.Rectangle backBox = drawManager.getBackButtonHitbox(this);
+
+        if (backBox.contains(mx, my)) {
+            drawManager.drawBackButton(this, true);
+        }
 
         drawManager.completeDrawing(this);
     }

--- a/src/screen/HighScoreScreen.java
+++ b/src/screen/HighScoreScreen.java
@@ -60,7 +60,7 @@ public class HighScoreScreen extends Screen {
         super.update();
 
         draw();
-        if (inputManager.isKeyDown(KeyEvent.VK_SPACE)
+        if (inputManager.isKeyDown(KeyEvent.VK_ESCAPE)
                 && this.inputDelay.checkFinished())
             this.isRunning = false;
 

--- a/src/screen/TitleScreen.java
+++ b/src/screen/TitleScreen.java
@@ -86,16 +86,20 @@ public class TitleScreen extends Screen {
                         this.isRunning = false;
                         break;
 
-                    case 1: // "Achievements" | High Scores -> Achievements
+                    case 1: // "Achievements"
                         this.returnCode = 3;
                         this.isRunning = false;
                         break;
-                    case 2: // "Settings"
+                    case 2: // "High scores"
+                        this.returnCode = 8;
+                        this.isRunning = false;
+                        break;
+                    case 3: // "Settings"
                         this.returnCode = 4;
                         this.isRunning = false;
                         break;
 
-                    case 3: // "Quit"
+                    case 4: // "Quit"
                         this.returnCode = 0;
                         this.isRunning = false;
                         break;
@@ -109,7 +113,7 @@ public class TitleScreen extends Screen {
                 int temp_y = inputManager.getMouseY();
 
                 java.awt.Rectangle[] boxes = drawManager.getMenuHitboxes(this);
-                int[] pos = {5, 3, 4, 0};
+                int[] pos = {5, 3, 8, 4, 0};
 
                 for (int i = 0; i < boxes.length; i++) {
                     if (boxes[i].contains(temp_x, temp_y)) {
@@ -126,14 +130,14 @@ public class TitleScreen extends Screen {
 	 * Shifts the focus to the next menu item. - modified for 2P mode selection
 	 */
 	private void nextMenuItem() {
-        this.menuIndex = (this.menuIndex + 1) % 4;
+        this.menuIndex = (this.menuIndex + 1) % 5;
 	}
 
 	/**
 	 * Shifts the focus to the previous menu item.
 	 */
 	private void previousMenuItem() {
-        this.menuIndex = (this.menuIndex + 3) % 4; // Fix : an issue where only the down arrow keys on the keyboard are entered and not up
+        this.menuIndex = (this.menuIndex + 4) % 5; // Fix : an issue where only the down arrow keys on the keyboard are entered and not up
     }
 	/**
 	 * Draws the elements associated with the screen.
@@ -156,6 +160,8 @@ public class TitleScreen extends Screen {
 			newHover = 2;
         if(boxesForHover[3].contains(mx, my))
             newHover = 3;
+        if(boxesForHover[4].contains(mx, my))
+            newHover = 4;
 
         // Modify : Update after hover calculation
         if (newHover != null) {


### PR DESCRIPTION
  **Core**
	•	Added returnCode = 8 for HighScoreScreen transition. 

  **DrawManager**
	•	Updated drawMenu() to include "High scores" in the button list.
	•	Added drawHighScoreMenu() to display High Scores title, instructions, and Back button.
	•	Refined text alignment and spacing for screen titles and button placement.

 **HighScoreScreen**
	•	Implemented Back button for returning to the TitleScreen.
	•	Added hover and click visual feedback for the Back button.
	•	Improved layout consistency with other UI screens (Achievements, Settings).

**TitleScreen**
	•	Added “High Scores” button to the main menu.
	•	Adjusted menu layout and spacing to fit the new button.
	•	Updated hover/click highlight logic for all menu items.

###  **ReturnCode List**

| `returnCode` | Screen / Action | Description |
|---------------|-----------------|--------------|
| **0** | Exit | Terminates the game. |
| **1** | TitleScreen | Returns to TitleScreen. |
| **2** | PlayScreen | Starts 1-Player or 2-Player mode. |
| **3** | GameOverScreen | Displays game over results. |
| **4** | SettingScreen | Opens the Settings menu. |
| **5** | PauseOverlay | Displays the in-game pause screen. |
| **6** | AchievementScreen | Opens the Achievements page. |
| **7** | ShipSelectionScreen | Displays the ship selection menu. |
| **8** | HighScoreScreen 🆕 | Opens the High Scores screen from TitleScreen. |